### PR TITLE
Removed input value from deault_error_message

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -642,7 +642,7 @@ class Field(object):
 
 class BooleanField(Field):
     default_error_messages = {
-        'invalid': _('"{input}" is not a valid boolean.')
+        'invalid': _('Is not a valid boolean.')
     }
     default_empty_html = False
     initial = False
@@ -687,7 +687,7 @@ class BooleanField(Field):
 
 class NullBooleanField(Field):
     default_error_messages = {
-        'invalid': _('"{input}" is not a valid boolean.')
+        'invalid': _('Is not a valid boolean.')
     }
     initial = None
     TRUE_VALUES = {
@@ -841,7 +841,7 @@ class UUIDField(Field):
     valid_formats = ('hex_verbose', 'hex', 'int', 'urn')
 
     default_error_messages = {
-        'invalid': _('"{value}" is not a valid UUID.'),
+        'invalid': _('Is not a valid UUID.'),
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Its never a good idea to return the provided input in an error message, as it can easily result in an reflected XSS. Imagine someone provides sends a form with a field like "<script>something evil</script>", you return the value and the frontend may not sanitize it proper, as it trusts its own backend. :)
